### PR TITLE
fixed bogus dates for rpmbuild

### DIFF
--- a/liveusb-creator.spec
+++ b/liveusb-creator.spec
@@ -151,7 +151,7 @@ rm -rf %{buildroot}
 * Thu Mar 12 2009 Luke Macken <lmacken@redhat.com> 3.6.3-1
 - Update to v3.6.3
 
-* Mon Mar 07 2009 Luke Macken <lmacken@redhat.com> 3.6-1
+* Mon Mar 09 2009 Luke Macken <lmacken@redhat.com> 3.6-1
 - Require pyparted
 - Update to v3.6
 
@@ -170,7 +170,7 @@ rm -rf %{buildroot}
 * Fri Jan 16 2009 Luke Macken <lmacken@redhat.com> 3.3-2
 - Require python-urlgrabber
 
-* Fri Jan 15 2009 Luke Macken <lmacken@redhat.com> 3.3-1
+* Thu Jan 15 2009 Luke Macken <lmacken@redhat.com> 3.3-1
 - Update to 3.3
 
 * Fri Jan 02 2009 Luke Macken <lmacken@redhat.com> 3.2-1


### PR DESCRIPTION
RPM build errors:
    bogus date in %changelog: Mon Mar 07 2009 Luke Macken lmacken@redhat.com 3.6-1
    bogus date in %changelog: Fri Jan 15 2009 Luke Macken lmacken@redhat.com 3.3-1

fixed according to changelog and code commit details
