### PR TITLE
Set graphics system to native to avoid blank windows when X server runs under user

### DIFF
--- a/liveusb/gui.py
+++ b/liveusb/gui.py
@@ -56,6 +56,9 @@ MAX_EXT = 2097152
 class LiveUSBApp(QtGui.QApplication):
     """ Main application class """
     def __init__(self, opts, args):
+        if sys.platform[:5] == 'linux':
+            QtGui.QApplication.setGraphicsSystem('native')
+
         QtGui.QApplication.__init__(self, args)
         self.mywindow = LiveUSBWindow(opts, args)
         self.mywindow.show()


### PR DESCRIPTION
Set graphics system to native to avoid blank windows when X server runs under user (not root) (rhbz#1212180). It's needed for Workstation spin in F22+. Qt upstream does not intend to fix it in Qt 4 but it's fixed in Qt 5.